### PR TITLE
fix: Gipuzkoa POLICY_DIGEST was outdated (refs #71)

### DIFF
--- a/src/Barnetik/Tbai/Xades/Gipuzkoa.php
+++ b/src/Barnetik/Tbai/Xades/Gipuzkoa.php
@@ -7,6 +7,6 @@ use lyquidity\xmldsig\XMLSecurityDSig;
 class Gipuzkoa extends TicketBai
 {
     const POLICY_IDENTIFIER = 'https://www.gipuzkoa.eus/ticketbai/sinadura';
-    const POLICY_DIGEST = 'vSe1CH7eAFVkGN0X2Y7Nl9XGUoBnziDA5BGUSsyt8mg=';
+    const POLICY_DIGEST = '4LDJbY5hqHHHX858s9QV1P8yVGzo6H23P/iNRRv+PnQ=';
     const ALGORITHM = XMLSecurityDSig::SHA256;
 }


### PR DESCRIPTION
Fixes the Gipuzkoa signature policy digest, left out when #63 updated Bizkaia and Araba.

`POLICY_IDENTIFIER` (`https://www.gipuzkoa.eus/ticketbai/sinadura`) resolves to `TicketBAI_Política_firma_v_1_2.pdf`. Its SHA-256, base64-encoded, is `4LDJbY5hqHHHX858s9QV1P8yVGzo6H23P/iNRRv+PnQ=`. The value currently on `main` corresponds to an earlier revision.

```bash
curl -sL https://www.gipuzkoa.eus/ticketbai/sinadura | openssl dgst -sha256 -binary | openssl base64
# 4LDJbY5hqHHHX858s9QV1P8yVGzo6H23P/iNRRv+PnQ=
```

`POLICY_IDENTIFIER` is correct and untouched; only the digest changes.

**Why CI stays green either way:** XSD validation does not check this. `ticketbaiv1-2-2.xsd` only constrains `SigPolicyHash/DigestValue` to be base64 — the value is validated by the tax authority on submission. A document carrying the stale digest validates cleanly against the official schema, which is what makes this easy to miss.

Details and reproduction in #71.